### PR TITLE
use portable method to determine arch

### DIFF
--- a/install-sdk.sh
+++ b/install-sdk.sh
@@ -144,7 +144,7 @@ case "$package_manager" in
 esac
 
 # enable XL compiler repo
-arch=$(uname -p)
+arch=$(uname -m)
 if [ "$arch" = ppc64le ]; then
 	XL_REPO_ROOT=http://public.dhe.ibm.com/software/server/POWER/Linux/xl-compiler/eval/$arch
 	case "$ID" in


### PR DESCRIPTION
Per the manpage for `uname` (coreutils 8.26), `uname -p` is not portable:
>        -m, --machine
>               print the machine hardware name
> 
>        -p, --processor
>               print the processor type (non-portable)

whereas `uname -m`, which ostensibly returns the desired information, is.

Use `uname -m` instead of `uname -p`.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>