### PR TITLE
Switch to "repos-only" mode by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ### Welcome
 
-We welcome contributions to the Power Functional Simulator Setup Project in many forms, and there's always plenty to do!
+We welcome contributions to the OpenPower SDK Automated Install in many forms, and there's always plenty to do!
 
 First things first, please review the Power Simulator Project's [Code of Conduct](https://github.com/hyperledger/hyperledger/wiki/Hyperledger-Project-Code-of-Conduct) before participating. It is important that we keep things civil.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/0b7cd13807d34db5af06a762037e75da)](https://www.codacy.com/app/rpsene/automated-install?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=open-power-sdk/automated-install&amp;utm_campaign=Badge_Grade)
 
 # Project Description
-This script automates the installation of the IBM SDK for Linux on Power, including all its dependencies.
+This script automates the configuration of the OpenPower SDK software repositories and all dependencies.
 
 ## Contributing to the project
-We welcome contributions to the Power Functional Simulator Setup Project in many forms. There's always plenty to do! Full details of how to contribute to this project are documented in the
+We welcome contributions to the OpenPower SDK Automated Install Project in many forms. There's always plenty to do! Full details of how to contribute to this project are documented in the
 [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 ## Maintainers
@@ -15,13 +15,15 @@ We use [Slack](https://toolsforpower.slack.org/) for communication.
 
 ## Supported Architecture and Operating Systems
 
-x86_64 and ppc64le: Ubuntu 16.04, CentOS7, RHEL 7.3, SLES12, Fedora 25.
+x86_64 and ppc64le: Ubuntu 16.04 and 18.04, CentOS7, RHEL 7, SLES12, Fedora 25.
+
+The script is likely to work on other distributions and releases, but has not been tested.
 
 ## Installing
 
-chmod +x ./install-sdk.sh
+chmod +x ./config-repos.sh
 
-./install-sdk.sh
+./config-repos.sh
 
 NOTE: ensure you are running this script as an user who has admin rights.
 
@@ -30,7 +32,7 @@ NOTE: ensure you are running this script as an user who has admin rights.
 For general purpose questions, please use [StackOverflow](http://stackoverflow.com/questions/tagged/toolsforpower).
 
 ## License <a name="license"></a>
-The Power Functional Simulator Setup Project uses the [Apache License Version 2.0](LICENSE) software license.
+The OpenPower SDK Automated Install Project uses the [Apache License Version 2.0](LICENSE) software license.
 
 ## Related information
-[IBM SDK for Linux on Power](https://developer.ibm.com/linuxonpower/sdk/)
+[OpenPower SDK](https://developer.ibm.com/linuxonpower/sdk/)


### PR DESCRIPTION
Removed documentation and steps where the IBM SDK for Linux on Power were
automatically installed.

"--repos-only" is now the default action for the script, so the option has
been removed.

Added some progress and error messages.

Also, fixed few places where the project name was incorrect (copy and paste
oversights).

Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>