### PR TITLE
Allow XL repo to work on RHEL 8

### DIFF
--- a/config-repos.sh
+++ b/config-repos.sh
@@ -211,7 +211,7 @@ if [ "$arch" = ppc64le ]; then
 			;;
 		rhel|centos)
 			# make sure it's 7
-			if [[ ${VERSION_ID%%.*} == 7 ]]; then
+			if [[ ${VERSION_ID%%.*} -ge 7 ]]; then
 				download $XL_REPO_ROOT/rhel7/repodata/repomd.xml.key
 				rpm --import repomd.xml.key
 				rm -f repomd.xml.key


### PR DESCRIPTION
The XL repository is at
http://public.dhe.ibm.com/software/server/POWER/Linux/xl-compiler/eval/ppc64le/rhel7/,
but it also works for RHEL 8, so allow that.

Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>